### PR TITLE
fix(linter): resolve all golangci-lint issues

### DIFF
--- a/internal/common/testutil/fixtures.go
+++ b/internal/common/testutil/fixtures.go
@@ -153,10 +153,6 @@ func NewTestInvoice(companyID string) *models.Invoice {
 	}
 }
 
-// Helper function to create pointer to float64
-func ptrFloat(f float64) *float64 {
-	return &f
-}
 
 // Helper function to create pointer to string
 func PtrString(s string) *string {

--- a/internal/tracking/service.go
+++ b/internal/tracking/service.go
@@ -265,7 +265,7 @@ func (s *Service) processDriverBehavior(gpsTrack *models.GPSTrack) {
 
 	// Check for speed violations (Indonesian speed limits)
 	if gpsTrack.Speed > 80 { // 80 km/h is typical urban speed limit in Indonesia
-		s.createDriverEvent(models.DriverEvent{
+		if err := s.createDriverEvent(models.DriverEvent{
 			DriverID:    *gpsTrack.DriverID,
 			VehicleID:   gpsTrack.VehicleID,
 			EventType:   "speed_violation",
@@ -274,7 +274,10 @@ func (s *Service) processDriverBehavior(gpsTrack *models.GPSTrack) {
 			Longitude:   gpsTrack.Longitude,
 			Speed:       gpsTrack.Speed,
 			Description: fmt.Sprintf("Speed violation: %.1f km/h", gpsTrack.Speed),
-		})
+		}); err != nil {
+			// Log error but don't fail the GPS tracking
+			fmt.Printf("Failed to create speed violation event: %v\n", err)
+		}
 	}
 
 	// Check for harsh braking
@@ -282,7 +285,7 @@ func (s *Service) processDriverBehavior(gpsTrack *models.GPSTrack) {
 		prevTrack := recentTracks[1]
 		deceleration := (prevTrack.Speed - gpsTrack.Speed) / float64(gpsTrack.Timestamp.Sub(prevTrack.Timestamp).Seconds())
 		if deceleration > 3.5 { // m/s² threshold for harsh braking
-			s.createDriverEvent(models.DriverEvent{
+			if err := s.createDriverEvent(models.DriverEvent{
 				DriverID:    *gpsTrack.DriverID,
 				VehicleID:   gpsTrack.VehicleID,
 				EventType:   "harsh_braking",
@@ -291,7 +294,10 @@ func (s *Service) processDriverBehavior(gpsTrack *models.GPSTrack) {
 				Longitude:   gpsTrack.Longitude,
 				Speed:       gpsTrack.Speed,
 				Description: fmt.Sprintf("Harsh braking: %.2f m/s²", deceleration),
-			})
+			}); err != nil {
+				// Log error but don't fail the GPS tracking
+				fmt.Printf("Failed to create harsh braking event: %v\n", err)
+			}
 		}
 	}
 
@@ -300,7 +306,7 @@ func (s *Service) processDriverBehavior(gpsTrack *models.GPSTrack) {
 		prevTrack := recentTracks[1]
 		acceleration := (gpsTrack.Speed - prevTrack.Speed) / float64(gpsTrack.Timestamp.Sub(prevTrack.Timestamp).Seconds())
 		if acceleration > 2.5 { // m/s² threshold for rapid acceleration
-			s.createDriverEvent(models.DriverEvent{
+			if err := s.createDriverEvent(models.DriverEvent{
 				DriverID:    *gpsTrack.DriverID,
 				VehicleID:   gpsTrack.VehicleID,
 				EventType:   "rapid_acceleration",
@@ -309,7 +315,10 @@ func (s *Service) processDriverBehavior(gpsTrack *models.GPSTrack) {
 				Longitude:   gpsTrack.Longitude,
 				Speed:       gpsTrack.Speed,
 				Description: fmt.Sprintf("Rapid acceleration: %.2f m/s²", acceleration),
-			})
+			}); err != nil {
+				// Log error but don't fail the GPS tracking
+				fmt.Printf("Failed to create rapid acceleration event: %v\n", err)
+			}
 		}
 	}
 }

--- a/internal/vehicle/history_service.go
+++ b/internal/vehicle/history_service.go
@@ -121,7 +121,7 @@ func (s *VehicleHistoryService) AddVehicleHistory(ctx context.Context, companyID
 	
 	// Convert documents to JSON
 	var documentsJSON json.RawMessage
-	if req.Documents != nil && len(req.Documents) > 0 {
+	if len(req.Documents) > 0 {
 		documentsJSON, err = json.Marshal(req.Documents)
 		if err != nil {
 			return nil, apperrors.NewInternalError("Failed to marshal documents").WithInternal(err)
@@ -436,7 +436,7 @@ func (s *VehicleHistoryService) UpdateVehicleHistory(ctx context.Context, compan
 	
 	// Convert documents to JSON
 	var documentsJSON json.RawMessage
-	if req.Documents != nil && len(req.Documents) > 0 {
+	if len(req.Documents) > 0 {
 		documentsJSON, err = json.Marshal(req.Documents)
 		if err != nil {
 			return nil, apperrors.NewInternalError("Failed to marshal documents").WithInternal(err)

--- a/seeds/utils.go
+++ b/seeds/utils.go
@@ -187,6 +187,7 @@ func ptrDate(t time.Time) *time.Time {
 
 // init initializes the random seed
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	// No need to call rand.Seed in Go 1.20+
+	// The global random number generator is automatically seeded
 }
 

--- a/seeds/vehicles.go
+++ b/seeds/vehicles.go
@@ -231,7 +231,4 @@ func SeedVehicles(db *gorm.DB) error {
 }
 
 // Helper functions for pointers
-func ptrDecimal(f float64) *float64 {
-	return &f
-}
 


### PR DESCRIPTION
Fixed all linter warnings and errors:

1. **Unchecked error returns (errcheck)**:
   - Fixed 3 unchecked createDriverEvent calls in tracking service
   - Added proper error handling with logging for GPS tracking events
   - Errors are logged but don't fail the GPS tracking process

2. **Unused functions (unused)**:
   - Removed unused ptrFloat() function from testutil/fixtures.go
   - Removed unused ptrDecimal() function from seeds/vehicles.go

3. **Deprecated rand.Seed (staticcheck)**:
   - Removed deprecated rand.Seed() call in seeds/utils.go
   - Added comment explaining Go 1.20+ auto-seeding

4. **Unnecessary nil checks (gosimple)**:
   - Fixed 2 instances of '!= nil && len() > 0' in history_service.go
   - Simplified to just 'len() > 0' as len() handles nil slices correctly

Files Modified:
- internal/tracking/service.go (3 error handling fixes)
- internal/vehicle/history_service.go (2 nil check simplifications)
- internal/common/testutil/fixtures.go (removed unused function)
- seeds/vehicles.go (removed unused function)
- seeds/utils.go (removed deprecated rand.Seed)

All changes maintain functionality while improving code quality. Linter should now pass with zero warnings/errors.